### PR TITLE
[FlightRPC] Flight SQL POC

### DIFF
--- a/format/FlightSQL.proto
+++ b/format/FlightSQL.proto
@@ -25,8 +25,9 @@ package arrow.flight.protocol.sql;
  * Wrap the result of a "GetSQLCapabilities" action.
  */
 message ActionGetSQLCapabilitiesResult{
-  string identifierQuoteString = 1;
-  bool supportsExpressionsInOrderBy = 2;
+  map<string, bytes> custom_fields = 1;
+  string identifier_quote_string = 2;
+  bool supports_expressions_in_order_by = 3;
   // TODO add more capabilities.
 }
 
@@ -37,17 +38,16 @@ message ActionGetSQLCapabilitiesResult{
  */
 message ActionGetCatalogsRequest {
   /*
-   * True will ensure results are ordered alphabetically.
-   * False will not enforce ordering.
+   * Specifies the order of result values.
    */ 
-  bool orderResultsAlphabetically = 1;
+  ResultsOrder order = 1;
 }
 
 /*
  * Wrap the result of a "GetCatalogs" action.
  */
 message ActionGetCatalogsResult {
-  repeated string catalogNames = 1;
+  repeated string catalog = 1;
 }
 
 /*
@@ -57,10 +57,11 @@ message ActionGetCatalogsResult {
  */
 message ActionGetSchemasRequest {
   /*
-   * True will ensure results are ordered alphabetically.
-   * False will not enforce ordering.
-   */ 
-  bool orderResultsAlphabetically = 1;
+   * Specifies the order of result values with prescendence:
+   *  - catalog
+   *  - schema
+   */
+  ResultsOrder order = 1;
 
   /*
    * Specifies the Catalog to search for schemas.
@@ -68,7 +69,7 @@ message ActionGetSchemasRequest {
   string catalog = 2;
 
   // Specifies a filter pattern for schemas to search for.
-  string schemaFilterPattern = 3;
+  string schema_filter_pattern = 3;
 }
 
 /*
@@ -86,25 +87,28 @@ message ActionGetSchemasResult {
  */
 message ActionGetTablesRequest {
   /*
-   * True will ensure results are ordered alphabetically.
-   * False will not enforce ordering.
-   */ 
-  bool orderResultsAlphabetically = 1;
+   * Specifies the order of result values with prescendence:
+   *  - catalog
+   *  - schema
+   *  - table_type
+   *  - table
+   */
+  ResultsOrder order = 1;
 
   // Specifies the Catalog to search for schemas.
   string catalog = 2;
 
   // Specifies a filter pattern for schemas to search for.
-  string schemaFilterPattern = 3;
+  string schema_filter_pattern = 3;
 
   // Specifies a filter pattern for tables to search for.
-  string tableNameFilterPattern = 4;
+  string table_name_filter_pattern = 4;
 
   // Specifies a filter of table types which must match.
-  repeated string tableTypes = 5;
+  repeated string table_types = 5;
 
   // Specifies if the schema should be returned for found tables.
-  bool includeSchema = 6; 
+  bool include_schema = 6; 
 }
 
 /*
@@ -114,20 +118,20 @@ message ActionGetTablesResult {
   string catalog = 1;
   string schema = 2;
   string table = 3;
-  string tableType = 4;
+  string table_type = 4;
 
   /*
    * Schema of the dataset as described in Schema.fbs::Schema,
    * Null if includeSchema on request is false.
    */
-  bytes schemaMetadata = 5; 
+  bytes arrow_metadata = 5; 
 }
 
 /*
  * Wrap the result of a "GetTableTypes" action.
  */
 message ActionGetTableTypesResult {
-  string tableType = 1;
+  string table_type = 1;
 }
 
 // SQL Execution Action Messages
@@ -148,15 +152,15 @@ message ActionGetPreparedStatementRequest {
 message ActionGetPreparedStatementResult {
 
   // Opaque handle for the prepared statement on the server.
-  bytes preparedStatementHandle = 1;
+  bytes prepared_statement_handle = 1;
 
   // If a result set generating query was provided, datasetSchema contains the 
   // schema of the dataset as described in Schema.fbs::Schema.
-  bytes datasetSchema = 2;
+  bytes dataset_schema = 2;
 
   // If the query provided contained parameters, parameterSchema contains the 
   // Schema of the expected parameters as described in Schema.fbs::Schema.
-  bytes parameterSchema = 3;
+  bytes parameter_schema = 3;
 }
 
 /*
@@ -166,7 +170,7 @@ message ActionGetPreparedStatementResult {
  */
 message ActionClosePreparedStatementRequest {
   // Opaque handle for the prepared statement on the server.
-  string preparedStatementHandle = 1;
+  string prepared_statement_handle = 1;
 }
 
 
@@ -191,9 +195,9 @@ message CommandStatementQuery {
  */
 message CommandPreparedStatementQuery {
   // Unique identifier for the instance of the prepared statement to execute.
-  bytes clientExecutionHandle = 1; 
+  bytes client_execution_handle = 1; 
   // Opaque handle for the prepared statement on the server.
-  bytes preparedStatementHandle = 2;
+  bytes prepared_statement_handle = 2;
 }
 
 /*
@@ -213,9 +217,9 @@ message CommandStatementUpdate {
  */
 message CommandPreparedStatementUpdate {
   // Unique identifier for the instance of the prepared statement to execute.
-  bytes clientExecutionHandle = 1; 
+  bytes client_execution_handle = 1; 
   // Opaque handle for the prepared statement on the server.
-  bytes preparedStatementHandle = 2;
+  bytes prepared_statement_handle = 2;
 }
 
 /*
@@ -226,5 +230,19 @@ message CommandPreparedStatementUpdate {
 message DoPutUpdateResult {
   // The number of records updated. A return value of -1 represents 
   // an unknown updated record count.
-  int64 recordCount = 1; 
+  int64 record_count = 1; 
+}
+
+enum ResultsOrder {
+  // Protobuf pattern, not used.
+  UNKNOWN = 0;
+
+  // No ordering enforcement.
+  UNORDERED = 1;
+
+  // Order results by ascending value order.
+  ASCENDING = 2;
+
+  // Order results by descending value order.
+  DESCENDING = 3;
 }

--- a/format/FlightSQL.proto
+++ b/format/FlightSQL.proto
@@ -175,11 +175,11 @@ message ActionGetPreparedStatementResult {
   // Opaque handle for the prepared statement on the server.
   bytes prepared_statement_handle = 1;
 
-  // If a result set generating query was provided, datasetSchema contains the 
+  // If a result set generating query was provided, dataset_schema contains the 
   // schema of the dataset as described in Schema.fbs::Schema.
   bytes dataset_schema = 2;
 
-  // If the query provided contained parameters, parameterSchema contains the 
+  // If the query provided contained parameters, parameter_schema contains the 
   // Schema of the expected parameters as described in Schema.fbs::Schema.
   bytes parameter_schema = 3;
 }

--- a/format/FlightSQL.proto
+++ b/format/FlightSQL.proto
@@ -150,10 +150,12 @@ message ActionGetPreparedStatementResult {
   // Opaque handle for the prepared statement on the server.
   bytes preparedStatementHandle = 1;
 
+  // If a result set generating query was provided, datasetSchema contains the 
   // schema of the dataset as described in Schema.fbs::Schema.
   bytes datasetSchema = 2;
 
-  // schema of the expected parameters, if any existed, as described in Schema.fbs::Schema.
+  // If the query provided contained parameters, parameterSchema contains the 
+  // Schema of the expected parameters as described in Schema.fbs::Schema.
   bytes parameterSchema = 3;
 }
 
@@ -178,7 +180,7 @@ message ActionClosePreparedStatementRequest {
  */
 message CommandStatementQuery {
   // The SQL syntax.
-  string query = 2;
+  string query = 1;
 }
 
 /*
@@ -189,9 +191,9 @@ message CommandStatementQuery {
  */
 message CommandPreparedStatementQuery {
   // Unique identifier for the instance of the prepared statement to execute.
-  bytes clientExecutionHandle = 2; 
+  bytes clientExecutionHandle = 1; 
   // Opaque handle for the prepared statement on the server.
-  bytes preparedStatementHandle = 3;
+  bytes preparedStatementHandle = 2;
 }
 
 /*
@@ -201,7 +203,7 @@ message CommandPreparedStatementQuery {
  */
 message CommandStatementUpdate {
   // The SQL syntax.
-  string query = 2;
+  string query = 1;
 }
 
 /*
@@ -211,16 +213,18 @@ message CommandStatementUpdate {
  */
 message CommandPreparedStatementUpdate {
   // Unique identifier for the instance of the prepared statement to execute.
-  bytes clientExecutionHandle = 2; 
+  bytes clientExecutionHandle = 1; 
   // Opaque handle for the prepared statement on the server.
-  bytes preparedStatementHandle = 3;
+  bytes preparedStatementHandle = 2;
 }
 
 /*
  * Returned from the RPC call DoPut when a CommandStatementUpdate
  * CommandPreparedStatementUpdate was in the request, containing
- * results from the update.
+ * results from the update. 
  */
 message DoPutUpdateResult {
+  // The number of records updated. A return value of -1 represents 
+  // an unknown updated record count.
   int64 recordCount = 1; 
 }

--- a/format/FlightSQL.proto
+++ b/format/FlightSQL.proto
@@ -22,13 +22,34 @@ option java_package = "org.apache.arrow.flight.sql.impl";
 package arrow.flight.protocol.sql;
 
 /*
- * Wrap the result of a "GetSQLCapabilities" action.
+ * Wrap the result of a "GetSQLInfo" action.
  */
-message ActionGetSQLCapabilitiesResult{
-  map<string, bytes> custom_fields = 1;
-  string identifier_quote_string = 2;
-  bool supports_expressions_in_order_by = 3;
-  // TODO add more capabilities.
+message ActionGetSQLInfoResult {
+  /*
+   * Values are based on Apache Hive's Thrift Service and
+   * ODBC's CLIGetInfo() function. Possible types include:
+   *  - CLI_IDENTIFIER_QUOTE_CHAR
+   *  - CLI_ORDER_BY_COLUMNS_IN_SELECT
+   *  - TODO add more info types.
+   */
+  map<string, TGetSQLInfoValue> flight_sql_info = 1;
+
+  // Implementation specific custom SQLInfo values.
+  map<string, TGetSQLInfoValue> custom_info = 2;
+}
+
+/*
+ * Wrapper for values returned in ActionGetSQLInfoResult.
+ */
+message TGetSQLInfoValue {
+  oneof value {
+    string stringValue = 1;
+    int32 integerValue = 2;
+    int32 integerBitmask = 3;
+    int32 integerFlag = 4;
+    bytes binaryValue = 5;
+    int64 longValue = 6;
+  }
 }
 
 /*
@@ -233,16 +254,18 @@ message DoPutUpdateResult {
   int64 record_count = 1; 
 }
 
-enum ResultsOrder {
-  // Protobuf pattern, not used.
-  UNKNOWN = 0;
+message ResultsOrder {
+  enum orders {
+    // Protobuf pattern, not used.
+    UNKNOWN = 0;
 
-  // No ordering enforcement.
-  UNORDERED = 1;
+    // No ordering enforcement.
+    UNORDERED = 1;
 
-  // Order results by ascending value order.
-  ASCENDING = 2;
+    // Order results by ascending value order.
+    ASCENDING = 2;
 
-  // Order results by descending value order.
-  DESCENDING = 3;
+    // Order results by descending value order.
+    DESCENDING = 3;
+  }
 }

--- a/format/FlightSQL.proto
+++ b/format/FlightSQL.proto
@@ -43,12 +43,12 @@ message ActionGetSQLInfoResult {
  */
 message TGetSQLInfoValue {
   oneof value {
-    string stringValue = 1;
-    int32 integerValue = 2;
-    int32 integerBitmask = 3;
-    int32 integerFlag = 4;
-    bytes binaryValue = 5;
-    int64 longValue = 6;
+    string string_value = 1;
+    int32 integer_value = 2;
+    int32 integer_bitmask = 3;
+    int32 integer_flag = 4;
+    bytes binary_value = 5;
+    int64 long_value = 6;
   }
 }
 

--- a/format/FlightSQL.proto
+++ b/format/FlightSQL.proto
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+option java_package = "org.apache.arrow.flight.sql.impl";
+package arrow.flight.protocol.sql;
+
+/*
+ * Wrap the result of a "GetSQLCapabilities" action.
+ */
+message ActionGetSQLCapabilitiesResult{
+  string identifierQuoteString = 1;
+  bool supportsExpressionsInOrderBy = 2;
+  // TODO add more capabilities.
+}
+
+/*
+ * Request message for the "GetCatalogs" action on a 
+ * Flight SQL enabled backend. 
+ * Requests a list of catalogs available in the server.
+ */
+message ActionGetCatalogsRequest {
+  /*
+   * True will ensure results are ordered alphabetically.
+   * False will not enforce ordering.
+   */ 
+  bool orderResultsAlphabetically = 1;
+}
+
+/*
+ * Wrap the result of a "GetCatalogs" action.
+ */
+message ActionGetCatalogsResult {
+  repeated string catalogNames = 1;
+}
+
+/*
+ * Request message for the "GetSchemas" action on a 
+ * Flight SQL enabled backend. 
+ * Requests a list of schemas available in the server.
+ */
+message ActionGetSchemasRequest {
+  /*
+   * True will ensure results are ordered alphabetically.
+   * False will not enforce ordering.
+   */ 
+  bool orderResultsAlphabetically = 1;
+
+  /*
+   * Specifies the Catalog to search for schemas.
+   */ 
+  string catalog = 2;
+
+  // Specifies a filter pattern for schemas to search for.
+  string schemaFilterPattern = 3;
+}
+
+/*
+ * Wrap the result of a "GetSchemas" action.
+ */
+message ActionGetSchemasResult {
+  string catalog = 1;
+  string schema = 2;
+}
+
+/*
+ * Request message for the "GetTables" action on a 
+ * Flight SQL enabled backend. 
+ * Requests a list of tables available in the server.
+ */
+message ActionGetTablesRequest {
+  /*
+   * True will ensure results are ordered alphabetically.
+   * False will not enforce ordering.
+   */ 
+  bool orderResultsAlphabetically = 1;
+
+  // Specifies the Catalog to search for schemas.
+  string catalog = 2;
+
+  // Specifies a filter pattern for schemas to search for.
+  string schemaFilterPattern = 3;
+
+  // Specifies a filter pattern for tables to search for.
+  string tableNameFilterPattern = 4;
+
+  // Specifies a filter of table types which must match.
+  repeated string tableTypes = 5;
+
+  // Specifies if the schema should be returned for found tables.
+  bool includeSchema = 6; 
+}
+
+/*
+ * Wrap the result of a "GetTables" action.
+ */
+message ActionGetTablesResult {
+  string catalog = 1;
+  string schema = 2;
+  string table = 3;
+  string tableType = 4;
+
+  /*
+   * Schema of the dataset as described in Schema.fbs::Schema,
+   * Null if includeSchema on request is false.
+   */
+  bytes schemaMetadata = 5; 
+}
+
+/*
+ * Wrap the result of a "GetTableTypes" action.
+ */
+message ActionGetTableTypesResult {
+  string tableType = 1;
+}
+
+// SQL Execution Action Messages
+
+/*
+ * Request message for the "GetPreparedStatement" action on a 
+ * Flight SQL enabled backend. 
+ * Requests a list of tables available in the server.
+ */
+message ActionGetPreparedStatementRequest {
+  // The SQL syntax.
+  string query = 1;
+}
+
+/*
+ * Wrap the result of a "GetPreparedStatement" action.
+ */
+message ActionGetPreparedStatementResult {
+
+  // Opaque handle for the prepared statement on the server.
+  bytes preparedStatementHandle = 1;
+
+  // schema of the dataset as described in Schema.fbs::Schema.
+  bytes datasetSchema = 2;
+
+  // schema of the expected parameters, if any existed, as described in Schema.fbs::Schema.
+  bytes parameterSchema = 3;
+}
+
+/*
+ * Request message for the "ClosePreparedStatement" action on a 
+ * Flight SQL enabled backend. 
+ * Closes server resources associated with the prepared statement handle.
+ */
+message ActionClosePreparedStatementRequest {
+  // Opaque handle for the prepared statement on the server.
+  string preparedStatementHandle = 1;
+}
+
+
+// SQL Execution Messages.
+
+/*
+ * Represents a SQL query. Used in the command member of FlightDescriptor
+ * for the following RPC calls:
+ *  - GetSchema: return the schema of the query.
+ *  - GetFlightInfo: execute the query.
+ */
+message CommandStatementQuery {
+  // The SQL syntax.
+  string query = 2;
+}
+
+/*
+ * Represents an instance of executing a prepared statement. Used in the 
+ * command member of FlightDescriptor for the following RPC calls:
+ *  - DoPut: bind parameter values.
+ *  - GetFlightInfo: execute the prepared statement instance.
+ */
+message CommandPreparedStatementQuery {
+  // Unique identifier for the instance of the prepared statement to execute.
+  bytes clientExecutionHandle = 2; 
+  // Opaque handle for the prepared statement on the server.
+  bytes preparedStatementHandle = 3;
+}
+
+/*
+ * Represents a SQL update query. Used in the command member of FlightDescriptor
+ * for the the RPC call DoPut to cause the server to execute the included 
+ * SQL update.
+ */
+message CommandStatementUpdate {
+  // The SQL syntax.
+  string query = 2;
+}
+
+/*
+ * Represents a SQL update query. Used in the command member of FlightDescriptor
+ * for the the RPC call DoPut to cause the server to execute the included 
+ * prepared statement handle as an update.
+ */
+message CommandPreparedStatementUpdate {
+  // Unique identifier for the instance of the prepared statement to execute.
+  bytes clientExecutionHandle = 2; 
+  // Opaque handle for the prepared statement on the server.
+  bytes preparedStatementHandle = 3;
+}
+
+/*
+ * Returned from the RPC call DoPut when a CommandStatementUpdate
+ * CommandPreparedStatementUpdate was in the request, containing
+ * results from the update.
+ */
+message DoPutUpdateResult {
+  int64 recordCount = 1; 
+}

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightRuntimeException.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightRuntimeException.java
@@ -29,7 +29,7 @@ public class FlightRuntimeException extends RuntimeException {
   /**
    * Create a new exception from the given status.
    */
-  FlightRuntimeException(CallStatus status) {
+  public FlightRuntimeException(CallStatus status) {
     super(status.description(), status.cause());
     this.status = status;
   }

--- a/java/flight/flight-sql/pom.xml
+++ b/java/flight/flight-sql/pom.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
+  license agreements. See the NOTICE file distributed with this work for additional
+  information regarding copyright ownership. The ASF licenses this file to
+  You under the Apache License, Version 2.0 (the "License"); you may not use
+  this file except in compliance with the License. You may obtain a copy of
+  the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+  by applicable law or agreed to in writing, software distributed under the
+  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+  OF ANY KIND, either express or implied. See the License for the specific
+  language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>arrow-java-root</artifactId>
+    <groupId>org.apache.arrow</groupId>
+    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>flight-sql</artifactId>
+  <name>Arrow Flight SQL</name>
+  <description>(Experimental)Contains utility classes to expose Flight SQL semantics for clients and servers over Arrow Flight</description>
+  <packaging>jar</packaging>
+
+  <properties>
+    <dep.grpc.version>1.30.2</dep.grpc.version>
+    <dep.protobuf.version>3.7.1</dep.protobuf.version>
+    <forkCount>1</forkCount>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>flight-core</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-unix-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-memory-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-memory-netty</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf</artifactId>
+      <version>${dep.grpc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+      <version>${dep.grpc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${dep.protobuf.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+      <version>${dep.grpc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>flight-core</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-vector</artifactId>
+      <version>${project.version}</version>
+      <classifier>${arrow.vector.classifier}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derby</artifactId>
+      <version>10.14.2.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-dbcp2</artifactId>
+      <version>2.7.0</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-pool2</artifactId>
+      <version>2.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <extensions>
+      <!-- provides os.detected.classifier (i.e. linux-x86_64, osx-x86_64) property -->
+      <extension>
+          <groupId>kr.motd.maven</groupId>
+          <artifactId>os-maven-plugin</artifactId>
+          <version>1.5.0.Final</version>
+      </extension>
+    </extensions>
+    <plugins>
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>0.5.0</version>
+        <configuration>
+          <protocArtifact>com.google.protobuf:protoc:${dep.protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+          <clearOutputDirectory>false</clearOutputDirectory>
+          <pluginId>grpc-java</pluginId>
+          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${dep.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+        </configuration>
+        <executions>
+          <execution>
+            <id>src</id>
+            <configuration>
+              <protoSourceRoot>${basedir}/../../../format/</protoSourceRoot>
+              <outputDirectory>${project.build.directory}/generated-sources/protobuf</outputDirectory>
+            </configuration>
+            <goals>
+              <goal>compile</goal>
+              <goal>compile-custom</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>test</id>
+            <configuration>
+              <protoSourceRoot>${basedir}/src/test/protobuf</protoSourceRoot>
+              <outputDirectory>${project.build.directory}/generated-test-sources//protobuf</outputDirectory>
+            </configuration>
+            <goals>
+              <goal>compile</goal>
+              <goal>compile-custom</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSQLClientUtils.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSQLClientUtils.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight.sql;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.arrow.flight.Action;
+import org.apache.arrow.flight.FlightClient;
+import org.apache.arrow.flight.FlightDescriptor;
+import org.apache.arrow.flight.FlightInfo;
+import org.apache.arrow.flight.Result;
+import org.apache.arrow.flight.sql.impl.FlightSQL;
+import org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetPreparedStatementResult;
+import org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetTablesRequest;
+import org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetTablesResult;
+import org.apache.arrow.flight.sql.impl.FlightSQL.CommandPreparedStatementQuery;
+import org.apache.arrow.vector.types.pojo.Schema;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
+
+import io.grpc.Status;
+
+/**
+ * Client side utilities to work with Flight SQL semantics.
+ */
+public final class FlightSQLClientUtils {
+
+  /**
+   * Helper method to request a list of tables from a Flight SQL enabled endpoint.
+   *
+   * @param client              The Flight Client.
+   * @param catalog             The catalog.
+   * @param schemaFilterPattern The schema filter pattern.
+   * @param tableFilterPattern  The table filter pattern.
+   * @param tableTypes          The table types to include.
+   * @param includeSchema       True to include the schema upon return, false to not include the schema.
+   * @return A list of tables matching the criteria.
+   */
+  public static List<ActionGetTablesResult> getTables(FlightClient client, String catalog, String schemaFilterPattern,
+          String tableFilterPattern, List<String> tableTypes, boolean includeSchema) {
+
+    final ActionGetTablesRequest.Builder requestBuilder = ActionGetTablesRequest
+            .newBuilder()
+            .setIncludeSchema(includeSchema);
+
+    if (catalog != null) {
+      requestBuilder.setCatalog(catalog);
+    }
+
+    if (schemaFilterPattern != null) {
+      requestBuilder.setSchemaFilterPattern(schemaFilterPattern);
+    }
+
+    if (tableFilterPattern != null) {
+      requestBuilder.setTableNameFilterPattern(tableFilterPattern);
+    }
+
+    if (tableTypes != null) {
+      requestBuilder.addAllTableTypes(tableTypes);
+    }
+
+    final Iterator<Result> results = client.doAction(new Action(
+            "GetTables", Any.pack(requestBuilder.build()).toByteArray()));
+
+    final List<ActionGetTablesResult> getTablesResults = new ArrayList<>();
+    results.forEachRemaining(result -> {
+      ActionGetTablesResult actual = FlightSQLUtils.unpackAndParseOrThrow(result.getBody(),
+              ActionGetTablesResult.class);
+      getTablesResults.add(actual);
+    });
+
+    return getTablesResults;
+  }
+
+  /**
+   * Helper method to create a prepared statement on the server.
+   *
+   * @param client The Flight Client.
+   * @param query  The query to prepare.
+   * @return Metadata and handles to the prepared statement which exists on the server.
+   */
+  public static FlightSQLPreparedStatement getPreparedStatement(FlightClient client, String query) {
+    return new FlightSQLPreparedStatement(client, query);
+  }
+
+  /**
+   * Helper class to encapsulate Flight SQL prepared statement logic.
+   */
+  public static class FlightSQLPreparedStatement implements Closeable {
+    private final FlightClient client;
+    private final ActionGetPreparedStatementResult preparedStatementResult;
+    private long invocationCount;
+    private boolean isClosed;
+    private Schema resultSetSchema = null;
+    private Schema parameterSchema = null;
+
+    /**
+     * Constructor.
+     *
+     * @param client The client. FlightSQLPreparedStatement does not maintain this resource.
+     * @param sql    The query.
+     */
+    public FlightSQLPreparedStatement(FlightClient client, String sql) {
+      this.client = client;
+
+      final Iterator<Result> preparedStatementResults = client.doAction(new Action("GetPreparedStatement",
+              Any.pack(FlightSQL.ActionGetPreparedStatementRequest
+                      .newBuilder()
+                      .setQuery(sql)
+                      .build())
+                      .toByteArray()));
+
+      preparedStatementResult = FlightSQLUtils.unpackAndParseOrThrow(
+              preparedStatementResults.next().getBody(),
+              ActionGetPreparedStatementResult.class);
+
+      invocationCount = 0;
+      isClosed = false;
+    }
+
+    /**
+     * Returns the Schema of the resultset.
+     *
+     * @return the Schema of the resultset.
+     */
+    public Schema getResultSetSchema() {
+      if (resultSetSchema == null && preparedStatementResult.getDatasetSchema() != null) {
+        resultSetSchema = Schema.deserialize(preparedStatementResult.getDatasetSchema().asReadOnlyByteBuffer());
+      }
+      return resultSetSchema;
+    }
+
+    /**
+     * Returns the Schema of the parameters.
+     *
+     * @return the Schema of the parameters.
+     */
+    public Schema getParameterSchema() {
+      if (parameterSchema == null && preparedStatementResult.getParameterSchema() != null) {
+        parameterSchema = Schema.deserialize(preparedStatementResult.getParameterSchema().asReadOnlyByteBuffer());
+      }
+      return parameterSchema;
+    }
+
+    /**
+     * Executes the prepared statement query on the server.
+     *
+     * @return a FlightInfo object representing the stream(s) to fetch.
+     * @throws IOException if the PreparedStatement is closed.
+     */
+    public FlightInfo executeQuery() throws IOException {
+      if (isClosed) {
+        throw new IOException("Prepared statement has already been closed on the server.");
+      }
+
+      final FlightDescriptor descriptor = FlightDescriptor
+              .command(Any.pack(CommandPreparedStatementQuery.newBuilder()
+                      .setClientExecutionHandle(
+                              ByteString.copyFrom(ByteBuffer.allocate(Long.BYTES).putLong(invocationCount++)))
+                      .setPreparedStatementHandle(preparedStatementResult.getPreparedStatementHandle())
+                      .build())
+                      .toByteArray());
+
+      return client.getInfo(descriptor);
+    }
+
+    /**
+     * Executes the prepared statement update on the server.
+     *
+     * @return the number of rows updated.
+     */
+    public long executeUpdate() {
+      throw Status.UNIMPLEMENTED.asRuntimeException();
+    }
+
+    @Override
+    public void close() {
+      isClosed = true;
+      final Iterator<Result> closePreparedStatementResults = client.doAction(new Action("ClosePreparedStatement",
+              Any.pack(FlightSQL.ActionClosePreparedStatementRequest
+                      .newBuilder()
+                      .setPreparedStatementHandleBytes(preparedStatementResult.getPreparedStatementHandle())
+                      .build())
+                      .toByteArray()));
+      closePreparedStatementResults.forEachRemaining(result -> {
+      });
+    }
+
+    /**
+     * Returns if the prepared statement is already closed.
+     *
+     * @return true if the prepared statement is already closed.
+     */
+    public boolean isClosed() {
+      return isClosed;
+    }
+  }
+}

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSQLProducer.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSQLProducer.java
@@ -22,7 +22,7 @@ import static org.apache.arrow.flight.sql.FlightSQLUtils.FLIGHT_SQL_CLOSEPREPARE
 import static org.apache.arrow.flight.sql.FlightSQLUtils.FLIGHT_SQL_GETCATALOGS;
 import static org.apache.arrow.flight.sql.FlightSQLUtils.FLIGHT_SQL_GETPREPAREDSTATEMENT;
 import static org.apache.arrow.flight.sql.FlightSQLUtils.FLIGHT_SQL_GETSCHEMAS;
-import static org.apache.arrow.flight.sql.FlightSQLUtils.FLIGHT_SQL_GETSQLCAPABILITIES;
+import static org.apache.arrow.flight.sql.FlightSQLUtils.FLIGHT_SQL_GETSQLINFO;
 import static org.apache.arrow.flight.sql.FlightSQLUtils.FLIGHT_SQL_GETTABLES;
 import static org.apache.arrow.flight.sql.FlightSQLUtils.FLIGHT_SQL_GETTABLETYPES;
 
@@ -181,7 +181,7 @@ public abstract class FlightSQLProducer implements FlightProducer, AutoCloseable
   @Override
   public void doAction(CallContext context, Action action, StreamListener<Result> listener) {
 
-    if (action.getType().equals(FLIGHT_SQL_GETSQLCAPABILITIES.getType())) {
+    if (action.getType().equals(FLIGHT_SQL_GETSQLINFO.getType())) {
       getSqlCapabilities(context, listener);
 
     } else if (action.getType().equals(FLIGHT_SQL_GETCATALOGS.getType())) {

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSQLProducer.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSQLProducer.java
@@ -182,7 +182,7 @@ public abstract class FlightSQLProducer implements FlightProducer, AutoCloseable
   public void doAction(CallContext context, Action action, StreamListener<Result> listener) {
 
     if (action.getType().equals(FLIGHT_SQL_GETSQLINFO.getType())) {
-      getSqlCapabilities(context, listener);
+      getSqlInfo(context, listener);
 
     } else if (action.getType().equals(FLIGHT_SQL_GETCATALOGS.getType())) {
       final ActionGetCatalogsRequest request = FlightSQLUtils.unpackAndParseOrThrow(action.getBody(),
@@ -215,13 +215,13 @@ public abstract class FlightSQLProducer implements FlightProducer, AutoCloseable
   }
 
   /**
-   * Returns the SQL Capabilities of the server by returning a
-   * {@link org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetSQLCapabilitiesResult} in a {@link Result}.
+   * Returns the SQL Info of the server by returning a
+   * {@link org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetSQLInfoResult} in a {@link Result}.
    *
    * @param context  Per-call context.
    * @param listener A stream of responses.
    */
-  public abstract void getSqlCapabilities(CallContext context, StreamListener<Result> listener);
+  public abstract void getSqlInfo(CallContext context, StreamListener<Result> listener);
 
   /**
    * Returns the available catalogs by returning a stream of

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSQLProducer.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSQLProducer.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight.sql;
+
+import static org.apache.arrow.flight.sql.FlightSQLUtils.FLIGHT_SQL_ACTIONS;
+import static org.apache.arrow.flight.sql.FlightSQLUtils.FLIGHT_SQL_CLOSEPREPAREDSTATEMENT;
+import static org.apache.arrow.flight.sql.FlightSQLUtils.FLIGHT_SQL_GETCATALOGS;
+import static org.apache.arrow.flight.sql.FlightSQLUtils.FLIGHT_SQL_GETPREPAREDSTATEMENT;
+import static org.apache.arrow.flight.sql.FlightSQLUtils.FLIGHT_SQL_GETSCHEMAS;
+import static org.apache.arrow.flight.sql.FlightSQLUtils.FLIGHT_SQL_GETSQLCAPABILITIES;
+import static org.apache.arrow.flight.sql.FlightSQLUtils.FLIGHT_SQL_GETTABLES;
+import static org.apache.arrow.flight.sql.FlightSQLUtils.FLIGHT_SQL_GETTABLETYPES;
+
+import org.apache.arrow.flight.Action;
+import org.apache.arrow.flight.ActionType;
+import org.apache.arrow.flight.FlightDescriptor;
+import org.apache.arrow.flight.FlightInfo;
+import org.apache.arrow.flight.FlightProducer;
+import org.apache.arrow.flight.FlightStream;
+import org.apache.arrow.flight.PutResult;
+import org.apache.arrow.flight.Result;
+import org.apache.arrow.flight.SchemaResult;
+import org.apache.arrow.flight.Ticket;
+import org.apache.arrow.flight.sql.impl.FlightSQL.ActionClosePreparedStatementRequest;
+import org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetCatalogsRequest;
+import org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetPreparedStatementRequest;
+import org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetSchemasRequest;
+import org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetTablesRequest;
+import org.apache.arrow.flight.sql.impl.FlightSQL.CommandPreparedStatementQuery;
+import org.apache.arrow.flight.sql.impl.FlightSQL.CommandPreparedStatementUpdate;
+import org.apache.arrow.flight.sql.impl.FlightSQL.CommandStatementQuery;
+import org.apache.arrow.flight.sql.impl.FlightSQL.CommandStatementUpdate;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import io.grpc.Status;
+
+/**
+ * API to Implement an Arrow Flight SQL producer.
+ */
+public abstract class FlightSQLProducer implements FlightProducer, AutoCloseable {
+
+  @Override
+  public FlightInfo getFlightInfo(CallContext context, FlightDescriptor descriptor) {
+    final Any command = FlightSQLUtils.parseOrThrow(descriptor.getCommand());
+
+    if (command.is(CommandStatementQuery.class)) {
+      return getFlightInfoStatement(FlightSQLUtils.unpackOrThrow(command, CommandStatementQuery.class), descriptor,
+              context);
+
+    } else if (command.is(CommandPreparedStatementQuery.class)) {
+      return getFlightInfoPreparedStatement(
+              FlightSQLUtils.unpackOrThrow(command, CommandPreparedStatementQuery.class), descriptor, context);
+    }
+
+    throw Status.INVALID_ARGUMENT.asRuntimeException();
+  }
+
+  /**
+   * Get information about a particular SQL query based data stream.
+   *
+   * @param command    The sql command to generate the data stream.
+   * @param context    Per-call context.
+   * @param descriptor The descriptor identifying the data stream.
+   * @return Metadata about the stream.
+   */
+  public abstract FlightInfo getFlightInfoStatement(CommandStatementQuery command, FlightDescriptor descriptor,
+          CallContext context);
+
+  /**
+   * Get information about a particular prepared statement data stream.
+   *
+   * @param command    The prepared statement to generate the data stream.
+   * @param context    Per-call context.
+   * @param descriptor The descriptor identifying the data stream.
+   * @return Metadata about the stream.
+   */
+  public abstract FlightInfo getFlightInfoPreparedStatement(CommandPreparedStatementQuery command,
+          FlightDescriptor descriptor, CallContext context);
+
+  @Override
+  public SchemaResult getSchema(CallContext context, FlightDescriptor descriptor) {
+    final Any command = FlightSQLUtils.parseOrThrow(descriptor.getCommand());
+
+    if (command.is(CommandStatementQuery.class)) {
+      return getSchemaStatement(FlightSQLUtils.unpackOrThrow(command, CommandStatementQuery.class), descriptor,
+              context);
+    }
+
+    throw Status.INVALID_ARGUMENT.asRuntimeException();
+  }
+
+  /**
+   * Get schema about a particular SQL query based data stream.
+   *
+   * @param command    The sql command to generate the data stream.
+   * @param context    Per-call context.
+   * @param descriptor The descriptor identifying the data stream.
+   * @return Schema for the stream.
+   */
+  public abstract SchemaResult getSchemaStatement(CommandStatementQuery command, FlightDescriptor descriptor,
+          CallContext context);
+
+  @Override
+  public Runnable acceptPut(CallContext context, FlightStream flightStream, StreamListener<PutResult> ackStream) {
+    final Any command = FlightSQLUtils.parseOrThrow(flightStream.getDescriptor().getCommand());
+
+    if (command.is(CommandStatementUpdate.class)) {
+      return acceptPutStatement(
+              FlightSQLUtils.unpackOrThrow(command, CommandStatementUpdate.class),
+              context, flightStream, ackStream);
+
+    } else if (command.is(CommandPreparedStatementUpdate.class)) {
+      return acceptPutPreparedStatementUpdate(
+              FlightSQLUtils.unpackOrThrow(command, CommandPreparedStatementUpdate.class),
+              context, flightStream, ackStream);
+
+    } else if (command.is(CommandPreparedStatementQuery.class)) {
+      return acceptPutPreparedStatementQuery(
+              FlightSQLUtils.unpackOrThrow(command, CommandPreparedStatementQuery.class),
+              context, flightStream, ackStream);
+    }
+
+    throw Status.INVALID_ARGUMENT.asRuntimeException();
+  }
+
+  /**
+   * Accept uploaded data for a particular SQL query based data stream. PutResults must be in the form of a
+   * {@link org.apache.arrow.flight.sql.impl.FlightSQL.DoPutUpdateResult}.
+   *
+   * @param command      The sql command to generate the data stream.
+   * @param context      Per-call context.
+   * @param flightStream The data stream being uploaded.
+   * @param ackStream    The result data stream.
+   * @return A runnable to process the stream.
+   */
+  public abstract Runnable acceptPutStatement(CommandStatementUpdate command, CallContext context,
+          FlightStream flightStream, StreamListener<PutResult> ackStream);
+
+  /**
+   * Accept uploaded data for a particular prepared statement data stream. PutResults must be in the form of a
+   * {@link org.apache.arrow.flight.sql.impl.FlightSQL.DoPutUpdateResult}.
+   *
+   * @param command      The prepared statement to generate the data stream.
+   * @param context      Per-call context.
+   * @param flightStream The data stream being uploaded.
+   * @param ackStream    The result data stream.
+   * @return A runnable to process the stream.
+   */
+  public abstract Runnable acceptPutPreparedStatementUpdate(CommandPreparedStatementUpdate command,
+          CallContext context, FlightStream flightStream, StreamListener<PutResult> ackStream);
+
+  /**
+   * Accept uploaded parameter values for a particular prepared statement query.
+   *
+   * @param command      The prepared statement the parameter values will bind to.
+   * @param context      Per-call context.
+   * @param flightStream The data stream being uploaded.
+   * @param ackStream    The result data stream.
+   * @return A runnable to process the stream.
+   */
+  public abstract Runnable acceptPutPreparedStatementQuery(CommandPreparedStatementQuery command,
+          CallContext context, FlightStream flightStream, StreamListener<PutResult> ackStream);
+
+  @Override
+  public void doAction(CallContext context, Action action, StreamListener<Result> listener) {
+
+    if (action.getType().equals(FLIGHT_SQL_GETSQLCAPABILITIES.getType())) {
+      getSqlCapabilities(context, listener);
+
+    } else if (action.getType().equals(FLIGHT_SQL_GETCATALOGS.getType())) {
+      final ActionGetCatalogsRequest request = FlightSQLUtils.unpackAndParseOrThrow(action.getBody(),
+              ActionGetCatalogsRequest.class);
+      getCatalogs(request, context, listener);
+
+    } else if (action.getType().equals(FLIGHT_SQL_GETSCHEMAS.getType())) {
+      final ActionGetSchemasRequest request = FlightSQLUtils.unpackAndParseOrThrow(action.getBody(),
+              ActionGetSchemasRequest.class);
+      getSchemas(request, context, listener);
+
+    } else if (action.getType().equals(FLIGHT_SQL_GETTABLES.getType())) {
+      final ActionGetTablesRequest request = FlightSQLUtils.unpackAndParseOrThrow(action.getBody(),
+              ActionGetTablesRequest.class);
+      getTables(request, context, listener);
+
+    } else if (action.getType().equals(FLIGHT_SQL_GETTABLETYPES.getType())) {
+      getTableTypes(context, listener);
+
+    } else if (action.getType().equals(FLIGHT_SQL_GETPREPAREDSTATEMENT.getType())) {
+      final ActionGetPreparedStatementRequest request = FlightSQLUtils.unpackAndParseOrThrow(action.getBody(),
+              ActionGetPreparedStatementRequest.class);
+      getPreparedStatement(request, context, listener);
+
+    } else if (action.getType().equals(FLIGHT_SQL_CLOSEPREPAREDSTATEMENT.getType())) {
+      final ActionClosePreparedStatementRequest request = FlightSQLUtils.unpackAndParseOrThrow(action.getBody(),
+              ActionClosePreparedStatementRequest.class);
+      closePreparedStatement(request, context, listener);
+    }
+  }
+
+  /**
+   * Returns the SQL Capabilities of the server by returning a
+   * {@link org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetSQLCapabilitiesResult} in a {@link Result}.
+   *
+   * @param context  Per-call context.
+   * @param listener A stream of responses.
+   */
+  public abstract void getSqlCapabilities(CallContext context, StreamListener<Result> listener);
+
+  /**
+   * Returns the available catalogs by returning a stream of
+   * {@link org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetCatalogsResult} objects in {@link Result} objects.
+   *
+   * @param request  request filter parameters.
+   * @param context  Per-call context.
+   * @param listener A stream of responses.
+   */
+  public abstract void getCatalogs(ActionGetCatalogsRequest request, CallContext context,
+          StreamListener<Result> listener);
+
+  /**
+   * Returns the available schemas by returning a stream of
+   * {@link org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetSchemasResult} objects in {@link Result} objects.
+   *
+   * @param request  request filter parameters.
+   * @param context  Per-call context.
+   * @param listener A stream of responses.
+   */
+  public abstract void getSchemas(ActionGetSchemasRequest request, CallContext context,
+          StreamListener<Result> listener);
+
+  /**
+   * Returns the available table types by returning a stream of
+   * {@link org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetTableTypesResult} objects in {@link Result} objects.
+   *
+   * @param context  Per-call context.
+   * @param listener A stream of responses.
+   */
+  public abstract void getTableTypes(CallContext context, StreamListener<Result> listener);
+
+  /**
+   * Returns the available tables by returning a stream of
+   * {@link org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetTablesResult} objects in {@link Result} objects.
+   *
+   * @param request  request filter parameters.
+   * @param context  Per-call context.
+   * @param listener A stream of responses.
+   */
+  public abstract void getTables(ActionGetTablesRequest request, CallContext context, StreamListener<Result> listener);
+
+  /**
+   * Creates a prepared statement on the server and returns a handle and metadata for in a
+   * {@link org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetPreparedStatementResult} object in a {@link Result}
+   * object.
+   *
+   * @param request  The sql command to generate the prepared statement.
+   * @param context  Per-call context.
+   * @param listener A stream of responses.
+   */
+  public abstract void getPreparedStatement(ActionGetPreparedStatementRequest request, CallContext context,
+          StreamListener<Result> listener);
+
+  /**
+   * Closes a prepared statement on the server. No result is expected.
+   *
+   * @param request  The sql command to generate the prepared statement.
+   * @param context  Per-call context.
+   * @param listener A stream of responses.
+   */
+  public abstract void closePreparedStatement(ActionClosePreparedStatementRequest request, CallContext context,
+          StreamListener<Result> listener);
+
+  @Override
+  public void listActions(CallContext context, StreamListener<ActionType> listener) {
+    FLIGHT_SQL_ACTIONS.forEach(action -> listener.onNext(action));
+    listener.onCompleted();
+  }
+
+  @Override
+  public void getStream(CallContext context, Ticket ticket, ServerStreamListener listener) {
+    final Any command;
+
+    try {
+      command = Any.parseFrom(ticket.getBytes());
+    } catch (InvalidProtocolBufferException e) {
+      listener.error(e);
+      return;
+    }
+
+    if (command.is(CommandStatementQuery.class)) {
+      getStreamStatement(FlightSQLUtils.unpackOrThrow(command, CommandStatementQuery.class),
+              context, ticket, listener);
+
+    } else if (command.is(CommandPreparedStatementQuery.class)) {
+      getStreamPreparedStatement(FlightSQLUtils.unpackOrThrow(command, CommandPreparedStatementQuery.class),
+              context, ticket, listener);
+    }
+
+    throw Status.INVALID_ARGUMENT.asRuntimeException();
+  }
+
+  /**
+   * Return data for a SQL query based data stream.
+   *
+   * @param command  The sql command to generate the data stream.
+   * @param context  Per-call context.
+   * @param ticket   The application-defined ticket identifying this stream.
+   * @param listener An interface for sending data back to the client.
+   */
+  public abstract void getStreamStatement(CommandStatementQuery command, CallContext context, Ticket ticket,
+          ServerStreamListener listener);
+
+  /**
+   * Return data for a particular prepared statement query instance.
+   *
+   * @param command  The prepared statement to generate the data stream.
+   * @param context  Per-call context.
+   * @param ticket   The application-defined ticket identifying this stream.
+   * @param listener An interface for sending data back to the client.
+   */
+  public abstract void getStreamPreparedStatement(CommandPreparedStatementQuery command, CallContext context,
+          Ticket ticket, ServerStreamListener listener);
+}

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSQLUtils.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSQLUtils.java
@@ -43,43 +43,43 @@ public final class FlightSQLUtils {
   private static final boolean IS_SIGNED_FALSE = false;
   private static final boolean IS_SIGNED_TRUE = true;
 
-  public static final ActionType FLIGHT_SQL_GETSQLCAPABILITIES = new ActionType("GetSQLCapabilities",
+  public static final ActionType FLIGHT_SQL_GETSQLINFO = new ActionType("GetSQLINFO",
           "Retrieves details of SQL capabilities of the Flight server. \n" +
                   "Request Message: N/A\n" +
-                  "Response Message: SQLCapabilitiesResult");
+                  "Response Message: ActionGetSQLInfoResult");
 
   public static final ActionType FLIGHT_SQL_GETCATALOGS = new ActionType("GetCatalogs",
           "Retrieves a list of all catalogs available on the server. \n" +
-                  "Request Message: GetCatalogsRequest\n" +
-                  "Response Message: GetCatalogsResult");
+                  "Request Message: ActionGetCatalogsRequest\n" +
+                  "Response Message: ActionGetCatalogsResult");
 
   public static final ActionType FLIGHT_SQL_GETSCHEMAS = new ActionType("GetSchemas",
           "Retrieves a list of schemas available on the server. \n" +
-                  "Request Message: GetSchemasRequest\n" +
-                  "Response Message: GetSchemasResult");
+                  "Request Message: ActionGetSchemasRequest\n" +
+                  "Response Message: ActionGetSchemasResult");
 
   public static final ActionType FLIGHT_SQL_GETTABLES = new ActionType("GetTables",
           "Retrieves a list of tables available on the server. \n" +
-                  "Request Message: GetTablesRequest\n" +
-                  "Response Message: GetTablesResult");
+                  "Request Message: ActionGetTablesRequest\n" +
+                  "Response Message: ActionGetTablesResult");
 
   public static final ActionType FLIGHT_SQL_GETTABLETYPES = new ActionType("GetTableTypes",
           "Retrieves a list of table types available on the server. \n" +
                   "Request Message: N/A\n" +
-                  "Response Message: GetTableTypesResult");
+                  "Response Message: ActionGetTableTypesResult");
 
   public static final ActionType FLIGHT_SQL_GETPREPAREDSTATEMENT = new ActionType("GetPreparedStatement",
           "Creates a reusable prepared statement resource on the server. \n" +
-                  "Request Message: ActionRequestGetPreparedStatement\n" +
-                  "Response Message: ActionResponseGetPreparedStatement");
+                  "Request Message: ActionGetPreparedStatementRequest\n" +
+                  "Response Message: ActionGetPreparedStatementResult");
 
   public static final ActionType FLIGHT_SQL_CLOSEPREPAREDSTATEMENT = new ActionType("ClosePreparedStatement",
           "Closes a reusable prepared statement resource on the server. \n" +
-                  "Request Message: ActionRequestClosePreparedStatement\n" +
+                  "Request Message: ActionClosePreparedStatementRequest\n" +
                   "Response Message: N/A");
 
   public static final List<ActionType> FLIGHT_SQL_ACTIONS = ImmutableList.of(
-          FLIGHT_SQL_GETSQLCAPABILITIES,
+          FLIGHT_SQL_GETSQLINFO,
           FLIGHT_SQL_GETCATALOGS,
           FLIGHT_SQL_GETSCHEMAS,
           FLIGHT_SQL_GETTABLES,

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSQLUtils.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSQLUtils.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight.sql;
+
+import java.sql.Types;
+import java.util.List;
+
+import org.apache.arrow.flight.ActionType;
+import org.apache.arrow.vector.types.DateUnit;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+
+/**
+ * Utilities to work with Flight SQL semantics.
+ */
+public final class FlightSQLUtils {
+
+  private static final int BIT_WIDTH8 = 8;
+  private static final int BIT_WIDTH_16 = 16;
+  private static final int BIT_WIDTH_32 = 32;
+  private static final int BIT_WIDTH_64 = 64;
+  private static final boolean IS_SIGNED_FALSE = false;
+  private static final boolean IS_SIGNED_TRUE = true;
+
+  public static final ActionType FLIGHT_SQL_GETSQLCAPABILITIES = new ActionType("GetSQLCapabilities",
+          "Retrieves details of SQL capabilities of the Flight server. \n" +
+                  "Request Message: N/A\n" +
+                  "Response Message: SQLCapabilitiesResult");
+
+  public static final ActionType FLIGHT_SQL_GETCATALOGS = new ActionType("GetCatalogs",
+          "Retrieves a list of all catalogs available on the server. \n" +
+                  "Request Message: GetCatalogsRequest\n" +
+                  "Response Message: GetCatalogsResult");
+
+  public static final ActionType FLIGHT_SQL_GETSCHEMAS = new ActionType("GetSchemas",
+          "Retrieves a list of schemas available on the server. \n" +
+                  "Request Message: GetSchemasRequest\n" +
+                  "Response Message: GetSchemasResult");
+
+  public static final ActionType FLIGHT_SQL_GETTABLES = new ActionType("GetTables",
+          "Retrieves a list of tables available on the server. \n" +
+                  "Request Message: GetTablesRequest\n" +
+                  "Response Message: GetTablesResult");
+
+  public static final ActionType FLIGHT_SQL_GETTABLETYPES = new ActionType("GetTableTypes",
+          "Retrieves a list of table types available on the server. \n" +
+                  "Request Message: N/A\n" +
+                  "Response Message: GetTableTypesResult");
+
+  public static final ActionType FLIGHT_SQL_GETPREPAREDSTATEMENT = new ActionType("GetPreparedStatement",
+          "Creates a reusable prepared statement resource on the server. \n" +
+                  "Request Message: ActionRequestGetPreparedStatement\n" +
+                  "Response Message: ActionResponseGetPreparedStatement");
+
+  public static final ActionType FLIGHT_SQL_CLOSEPREPAREDSTATEMENT = new ActionType("ClosePreparedStatement",
+          "Closes a reusable prepared statement resource on the server. \n" +
+                  "Request Message: ActionRequestClosePreparedStatement\n" +
+                  "Response Message: N/A");
+
+  public static final List<ActionType> FLIGHT_SQL_ACTIONS = ImmutableList.of(
+          FLIGHT_SQL_GETSQLCAPABILITIES,
+          FLIGHT_SQL_GETCATALOGS,
+          FLIGHT_SQL_GETSCHEMAS,
+          FLIGHT_SQL_GETTABLES,
+          FLIGHT_SQL_GETTABLETYPES,
+          FLIGHT_SQL_GETPREPAREDSTATEMENT,
+          FLIGHT_SQL_CLOSEPREPAREDSTATEMENT
+  );
+
+  /**
+   * Converts {@link java.sql.Types} values returned from JDBC Apis to Arrow types.
+   *
+   * @param jdbcDataType {@link java.sql.Types} value.
+   * @param precision    Precision of the type.
+   * @param scale        Scale of the type.
+   * @return The Arrow equivalent type.
+   */
+  public static ArrowType getArrowTypeFromJDBCType(int jdbcDataType, int precision, int scale) {
+
+    switch (jdbcDataType) {
+      case Types.BIT:
+      case Types.BOOLEAN:
+        return ArrowType.Bool.INSTANCE;
+      case Types.TINYINT:
+        return new ArrowType.Int(BIT_WIDTH8, IS_SIGNED_TRUE);
+      case Types.SMALLINT:
+        return new ArrowType.Int(BIT_WIDTH_16, IS_SIGNED_TRUE);
+      case Types.INTEGER:
+        return new ArrowType.Int(BIT_WIDTH_32, IS_SIGNED_TRUE);
+      case Types.BIGINT:
+        return new ArrowType.Int(BIT_WIDTH_64, IS_SIGNED_TRUE);
+      case Types.FLOAT:
+      case Types.REAL:
+        return new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE);
+      case Types.DOUBLE:
+        return new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE);
+      case Types.NUMERIC:
+      case Types.DECIMAL:
+        return new ArrowType.Decimal(precision, scale);
+      case Types.DATE:
+        return new ArrowType.Date(DateUnit.DAY);
+      case Types.TIME:
+        return new ArrowType.Time(TimeUnit.MILLISECOND, BIT_WIDTH_32);
+      case Types.TIMESTAMP:
+        return new ArrowType.Timestamp(TimeUnit.MILLISECOND, null);
+      case Types.BINARY:
+      case Types.VARBINARY:
+      case Types.LONGVARBINARY:
+        return ArrowType.Binary.INSTANCE;
+      case Types.NULL:
+        return ArrowType.Null.INSTANCE;
+
+      case Types.CHAR:
+      case Types.VARCHAR:
+      case Types.LONGVARCHAR:
+      case Types.CLOB:
+      case Types.NCHAR:
+      case Types.NVARCHAR:
+      case Types.LONGNVARCHAR:
+      case Types.NCLOB:
+
+      case Types.OTHER:
+      case Types.JAVA_OBJECT:
+      case Types.DISTINCT:
+      case Types.STRUCT:
+      case Types.ARRAY:
+      case Types.BLOB:
+      case Types.REF:
+      case Types.DATALINK:
+      case Types.ROWID:
+      case Types.SQLXML:
+      case Types.REF_CURSOR:
+      case Types.TIME_WITH_TIMEZONE:
+      case Types.TIMESTAMP_WITH_TIMEZONE:
+      default:
+        return ArrowType.Utf8.INSTANCE;
+      //        throw new UnsupportedOperationException();
+    }
+  }
+
+  /**
+   * Helper to parse {@link com.google.protobuf.Any} objects to the specific protobuf object.
+   *
+   * @param source the raw bytes source value.
+   * @return the materialized protobuf object.
+   */
+  public static Any parseOrThrow(byte[] source) {
+    try {
+      return Any.parseFrom(source);
+    } catch (InvalidProtocolBufferException e) {
+      throw new AssertionError(e.getMessage());
+    }
+  }
+
+  /**
+   * Helper to unpack {@link com.google.protobuf.Any} objects to the specific protobuf object.
+   *
+   * @param source the parsed Source value.
+   * @param as     the class to unpack as.
+   * @param <T>    the class to unpack as.
+   * @return the materialized protobuf object.
+   */
+  public static <T extends Message> T unpackOrThrow(Any source, Class<T> as) {
+    try {
+      return source.unpack(as);
+    } catch (InvalidProtocolBufferException e) {
+      throw new AssertionError(e.getMessage());
+    }
+  }
+
+  /**
+   * Helper to parse and unpack {@link com.google.protobuf.Any} objects to the specific protobuf object.
+   *
+   * @param source the raw bytes source value.
+   * @param as     the class to unpack as.
+   * @param <T>    the class to unpack as.
+   * @return the materialized protobuf object.
+   */
+  public static <T extends Message> T unpackAndParseOrThrow(byte[] source, Class<T> as) {
+    return unpackOrThrow(parseOrThrow(source), as);
+  }
+}

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/TestFlightSQL.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/TestFlightSQL.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight;
+
+import static org.apache.arrow.flight.sql.FlightSQLClientUtils.getPreparedStatement;
+import static org.apache.arrow.flight.sql.FlightSQLClientUtils.getTables;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.arrow.flight.sql.FlightSQLClientUtils;
+import org.apache.arrow.flight.sql.FlightSQLExample;
+import org.apache.arrow.flight.sql.impl.FlightSQL.ActionClosePreparedStatementRequest;
+import org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetPreparedStatementRequest;
+import org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetPreparedStatementResult;
+import org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetTablesRequest;
+import org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetTablesResult;
+import org.apache.arrow.flight.sql.impl.FlightSQL.CommandPreparedStatementQuery;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.memory.util.ArrowBufPointer;
+import org.apache.arrow.util.AutoCloseables;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.arrow.vector.util.ElementAddressableVectorIterator;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
+
+/**
+ * Test direct usage of Flight SQL workflows.
+ */
+public class TestFlightSQL {
+  private static BufferAllocator allocator;
+  private static FlightServer server;
+
+  private static FlightClient client;
+
+  protected static final Schema SCHEMA_INT_TABLE = new Schema(Arrays.asList(
+          new Field("KEYNAME", new
+                  FieldType(true, ArrowType.Utf8.INSTANCE, null),
+                  null),
+          new Field("VALUE",
+                  new FieldType(true, new ArrowType.Int(32, true), null),
+                  null)));
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    allocator = new RootAllocator(Integer.MAX_VALUE);
+
+    final Location serverLocation = Location.forGrpcInsecure(FlightTestUtil.LOCALHOST, 0);
+    server = FlightServer.builder(allocator, serverLocation, new FlightSQLExample(serverLocation)).build();
+    server.start();
+
+    final Location clientLocation = Location.forGrpcInsecure(FlightTestUtil.LOCALHOST, server.getPort());
+    client = FlightClient.builder(allocator, clientLocation).build();
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    AutoCloseables.close(client, server, allocator);
+  }
+
+  @Test
+  public void testGetTables() throws Exception {
+    // Arrange
+    final ActionGetTablesResult expected = ActionGetTablesResult.newBuilder()
+            .setSchema("APP")
+            .setTable("INTTABLE")
+            .setTableType("TABLE")
+            .setSchemaMetadata(ByteString.copyFrom(SCHEMA_INT_TABLE.toByteArray()))
+            .build();
+
+    // Act
+    final Iterator<Result> results = client.doAction(new Action("GetTables",
+            Any.pack(ActionGetTablesRequest
+                    .newBuilder()
+                    .addTableTypes("TABLE")
+                    .setIncludeSchema(true)
+                    .build())
+                    .toByteArray()));
+
+    // Assert
+    while (results.hasNext()) {
+      ActionGetTablesResult actual = Any.parseFrom(results.next().getBody()).unpack(ActionGetTablesResult.class);
+      assertEquals(expected, actual);
+    }
+  }
+
+  @Test
+  public void testGetTablesWithFlightSQLClientUtils() throws Exception {
+    // Arrange
+    final ActionGetTablesResult expected = ActionGetTablesResult.newBuilder()
+            .setSchema("APP")
+            .setTable("INTTABLE")
+            .setTableType("TABLE")
+            .setSchemaMetadata(ByteString.copyFrom(SCHEMA_INT_TABLE.toByteArray()))
+            .build();
+
+    // Act
+    final List<ActionGetTablesResult> results = getTables(client, null, null, null,
+            Collections.singletonList("TABLE"), true);
+
+    // Assert
+    assertEquals(1, results.size());
+    assertEquals(expected, results.get(0));
+  }
+
+  @Test
+  public void testSimplePrepStmt() throws Exception {
+    final Iterator<Result> preparedStatementResults = client.doAction(new Action("GetPreparedStatement",
+            Any.pack(ActionGetPreparedStatementRequest
+                    .newBuilder()
+                    .setQuery("Select * from intTable")
+                    .build())
+                    .toByteArray()));
+
+    assertTrue(preparedStatementResults.hasNext());
+    final ActionGetPreparedStatementResult preparedStatementResult =
+            Any.parseFrom(preparedStatementResults.next().getBody()).unpack(ActionGetPreparedStatementResult.class);
+    assertFalse(preparedStatementResults.hasNext());
+
+    final Schema actualSchema = Schema.deserialize(preparedStatementResult.getDatasetSchema().asReadOnlyByteBuffer());
+    assertEquals(SCHEMA_INT_TABLE, actualSchema);
+
+    final FlightDescriptor descriptor = FlightDescriptor
+            .command(Any.pack(CommandPreparedStatementQuery.newBuilder()
+                    .setClientExecutionHandle(ByteString.copyFrom(new byte[]{1, 2, 3, 4}))
+                    .setPreparedStatementHandle(preparedStatementResult.getPreparedStatementHandle())
+                    .build())
+                    .toByteArray());
+
+    final FlightInfo info = client.getInfo(descriptor);
+    assertEquals(SCHEMA_INT_TABLE, info.getSchema());
+
+    final FlightStream stream = client.getStream(info.getEndpoints().get(0).getTicket());
+    assertEquals(SCHEMA_INT_TABLE, stream.getSchema());
+
+    List<String> actualStringResults = new ArrayList<>();
+    List<Integer> actualIntResults = new ArrayList<>();
+    while (stream.next()) {
+      final VectorSchemaRoot root = stream.getRoot();
+      final long rowCount = root.getRowCount();
+
+      for (Field field : root.getSchema().getFields()) {
+        final FieldVector fieldVector = root.getVector(field.getName());
+
+        if (fieldVector instanceof VarCharVector) {
+
+          final ElementAddressableVectorIterator<VarCharVector> it =
+                  new ElementAddressableVectorIterator<>((VarCharVector) fieldVector);
+
+          for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+            final ArrowBufPointer pt = it.next();
+            final byte[] bytes = new byte[(int) pt.getLength()];
+            pt.getBuf().getBytes(pt.getOffset(), bytes);
+
+            actualStringResults.add(new String(bytes, StandardCharsets.UTF_8));
+          }
+        } else if (fieldVector instanceof IntVector) {
+          for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+            actualIntResults.add(((IntVector) fieldVector).get(rowIndex));
+          }
+        }
+      }
+    }
+    stream.getRoot().clear();
+
+    assertEquals(Arrays.asList("one", "zero", "negative one"), actualStringResults);
+    assertEquals(Arrays.asList(1, 0, -1), actualIntResults);
+
+    final Iterator<Result> closePreparedStatementResults = client.doAction(new Action("ClosePreparedStatement",
+            Any.pack(ActionClosePreparedStatementRequest
+                    .newBuilder()
+                    .setPreparedStatementHandleBytes(preparedStatementResult.getPreparedStatementHandle())
+                    .build())
+                    .toByteArray()));
+    assertFalse(closePreparedStatementResults.hasNext());
+  }
+
+  @Test
+  public void testSimplePrepStmtWithFlightSQLClientUtils() throws Exception {
+    final FlightSQLClientUtils.FlightSQLPreparedStatement preparedStatement =
+            getPreparedStatement(client, "Select * from intTable");
+
+    final Schema actualSchema = preparedStatement.getResultSetSchema();
+    assertEquals(SCHEMA_INT_TABLE, actualSchema);
+
+    final FlightInfo info = preparedStatement.executeQuery();
+    assertEquals(SCHEMA_INT_TABLE, info.getSchema());
+
+    final FlightStream stream = client.getStream(info.getEndpoints().get(0).getTicket());
+    assertEquals(SCHEMA_INT_TABLE, stream.getSchema());
+
+    List<String> actualStringResults = new ArrayList<>();
+    List<Integer> actualIntResults = new ArrayList<>();
+    while (stream.next()) {
+      final VectorSchemaRoot root = stream.getRoot();
+      final long rowCount = root.getRowCount();
+
+      for (Field field : root.getSchema().getFields()) {
+        final FieldVector fieldVector = root.getVector(field.getName());
+
+        if (fieldVector instanceof VarCharVector) {
+
+          final ElementAddressableVectorIterator<VarCharVector> it =
+                  new ElementAddressableVectorIterator<>((VarCharVector) fieldVector);
+
+          for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+            final ArrowBufPointer pt = it.next();
+            final byte[] bytes = new byte[(int) pt.getLength()];
+            pt.getBuf().getBytes(pt.getOffset(), bytes);
+
+            actualStringResults.add(new String(bytes, StandardCharsets.UTF_8));
+          }
+        } else if (fieldVector instanceof IntVector) {
+          for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+            actualIntResults.add(((IntVector) fieldVector).get(rowIndex));
+          }
+        }
+      }
+    }
+    stream.getRoot().clear();
+
+    assertEquals(Arrays.asList("one", "zero", "negative one"), actualStringResults);
+    assertEquals(Arrays.asList(1, 0, -1), actualIntResults);
+
+    AutoCloseables.close(preparedStatement);
+    assertTrue(preparedStatement.isClosed());
+  }
+}

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/TestFlightSQL.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/TestFlightSQL.java
@@ -99,7 +99,7 @@ public class TestFlightSQL {
             .setSchema("APP")
             .setTable("INTTABLE")
             .setTableType("TABLE")
-            .setSchemaMetadata(ByteString.copyFrom(SCHEMA_INT_TABLE.toByteArray()))
+            .setArrowMetadata(ByteString.copyFrom(SCHEMA_INT_TABLE.toByteArray()))
             .build();
 
     // Act
@@ -125,7 +125,7 @@ public class TestFlightSQL {
             .setSchema("APP")
             .setTable("INTTABLE")
             .setTableType("TABLE")
-            .setSchemaMetadata(ByteString.copyFrom(SCHEMA_INT_TABLE.toByteArray()))
+            .setArrowMetadata(ByteString.copyFrom(SCHEMA_INT_TABLE.toByteArray()))
             .build();
 
     // Act

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/FlightSQLExample.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/FlightSQLExample.java
@@ -1,0 +1,601 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight.sql;
+
+import static org.apache.arrow.flight.sql.FlightSQLUtils.getArrowTypeFromJDBCType;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ParameterMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
+
+import org.apache.arrow.flight.CallStatus;
+import org.apache.arrow.flight.Criteria;
+import org.apache.arrow.flight.FlightDescriptor;
+import org.apache.arrow.flight.FlightEndpoint;
+import org.apache.arrow.flight.FlightInfo;
+import org.apache.arrow.flight.FlightRuntimeException;
+import org.apache.arrow.flight.FlightStatusCode;
+import org.apache.arrow.flight.FlightStream;
+import org.apache.arrow.flight.Location;
+import org.apache.arrow.flight.PutResult;
+import org.apache.arrow.flight.Result;
+import org.apache.arrow.flight.SchemaResult;
+import org.apache.arrow.flight.Ticket;
+import org.apache.arrow.flight.sql.impl.FlightSQL;
+import org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetPreparedStatementResult;
+import org.apache.arrow.flight.sql.impl.FlightSQL.ActionGetTablesResult;
+import org.apache.arrow.flight.sql.impl.FlightSQL.CommandPreparedStatementQuery;
+import org.apache.arrow.flight.sql.impl.FlightSQL.CommandPreparedStatementUpdate;
+import org.apache.arrow.flight.sql.impl.FlightSQL.CommandStatementQuery;
+import org.apache.arrow.flight.sql.impl.FlightSQL.CommandStatementUpdate;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.util.AutoCloseables;
+import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.dictionary.DictionaryProvider;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.commons.dbcp2.ConnectionFactory;
+import org.apache.commons.dbcp2.DriverManagerConnectionFactory;
+import org.apache.commons.dbcp2.PoolableConnection;
+import org.apache.commons.dbcp2.PoolableConnectionFactory;
+import org.apache.commons.dbcp2.PoolingDataSource;
+import org.apache.commons.pool2.ObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import io.grpc.Status;
+
+/**
+ * Proof of concept {@link FlightSQLProducer} implementation showing an Apache Derby backed Flight SQL server capable
+ * of the following workflows:
+ * - returning a list of tables from the action "GetTables".
+ * - creation of a prepared statement from the action "GetPreparedStatement".
+ * - execution of a prepared statement by using a {@link CommandPreparedStatementQuery} with getFlightInfo and
+ * getStream.
+ */
+public class FlightSQLExample extends FlightSQLProducer implements AutoCloseable {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FlightSQLExample.class);
+
+  private static final int BATCH_ROW_SIZE = 1000;
+
+  private final Location location;
+  private final PoolingDataSource<PoolableConnection> dataSource;
+
+  private final LoadingCache<CommandPreparedStatementQuery, ResultSet> commandExecutePreparedStatementLoadingCache;
+  private final LoadingCache<PreparedStatementCacheKey, PreparedStatementContext> preparedStatementLoadingCache;
+
+  public FlightSQLExample(Location location) {
+    removeDerbyDatabaseIfExists();
+    populateDerbyDatabase();
+
+    final ConnectionFactory connectionFactory =
+            new DriverManagerConnectionFactory("jdbc:derby:target/derbyDB", null);
+    final PoolableConnectionFactory poolableConnectionFactory = new PoolableConnectionFactory(connectionFactory, null);
+    final ObjectPool<PoolableConnection> connectionPool = new GenericObjectPool<>(poolableConnectionFactory);
+    poolableConnectionFactory.setPool(connectionPool);
+
+    // PoolingDataSource takes ownership of connectionPool.
+    dataSource = new PoolingDataSource<>(connectionPool);
+
+    preparedStatementLoadingCache =
+            CacheBuilder.newBuilder()
+                    .maximumSize(100)
+                    .expireAfterWrite(10, java.util.concurrent.TimeUnit.MINUTES)
+                    .removalListener(new PreparedStatementRemovalListener())
+                    .build(new PreparedStatementCacheLoader(dataSource));
+
+    commandExecutePreparedStatementLoadingCache =
+            CacheBuilder.newBuilder()
+                    .maximumSize(100)
+                    .expireAfterWrite(10, java.util.concurrent.TimeUnit.MINUTES)
+                    .removalListener(new CommandExecutePreparedStatementRemovalListener())
+                    .build(new CommandExecutePreparedStatementCacheLoader(preparedStatementLoadingCache));
+
+    this.location = location;
+  }
+
+  @Override
+  public void getTables(FlightSQL.ActionGetTablesRequest request, CallContext context,
+          StreamListener<Result> listener) {
+    try {
+      final String catalog = (request.getCatalog().isEmpty() ? null : request.getCatalog());
+
+      final String schemaFilterPattern =
+              (request.getSchemaFilterPattern().isEmpty() ? null : request.getSchemaFilterPattern());
+
+      final String tableFilterPattern =
+              (request.getTableNameFilterPattern().isEmpty() ? null : request.getTableNameFilterPattern());
+
+      final String[] tableTypes = request.getTableTypesList().size() == 0 ? null :
+              request.getTableTypesList().toArray(new String[request.getTableTypesList().size()]);
+
+      try (final Connection connection = dataSource.getConnection();
+           final ResultSet tables = connection.getMetaData().getTables(
+                   catalog,
+                   schemaFilterPattern,
+                   tableFilterPattern,
+                   tableTypes)) {
+        while (tables.next()) {
+          listener.onNext(getTableResult(tables, request.getIncludeSchema()));
+        }
+      }
+    } catch (SQLException e) {
+      listener.onError(e);
+    } finally {
+      listener.onCompleted();
+    }
+  }
+
+  private Result getTableResult(final ResultSet tables, boolean includeSchema) throws SQLException {
+
+    final String catalog = tables.getString("TABLE_CAT");
+    final String schema = tables.getString("TABLE_SCHEM");
+    final String table = tables.getString("TABLE_NAME");
+    final String tableType = tables.getString("TABLE_TYPE");
+
+    final ActionGetTablesResult.Builder builder = ActionGetTablesResult.newBuilder()
+            .setCatalog(catalog)
+            .setSchema(schema)
+            .setTable(table)
+            .setTableType(tableType);
+
+    if (includeSchema) {
+      final Schema pojoSchema = buildSchema(catalog, schema, table);
+      builder.setSchemaMetadata(ByteString.copyFrom(pojoSchema.toByteArray()));
+    }
+
+    return new Result(Any.pack(builder.build()).toByteArray());
+  }
+
+  @Override
+  public void getPreparedStatement(FlightSQL.ActionGetPreparedStatementRequest request, CallContext context,
+          StreamListener<Result> listener) {
+    final PreparedStatementCacheKey handle = new PreparedStatementCacheKey(
+            UUID.randomUUID().toString(), request.getQuery());
+
+    try {
+      final PreparedStatementContext preparedStatementContext = preparedStatementLoadingCache.get(handle);
+      final PreparedStatement preparedStatement = preparedStatementContext.getPreparedStatement();
+
+      // todo
+      final Schema pojoParameterMetaDataSchema = buildSchema(preparedStatement.getParameterMetaData());
+      final Schema pojoResultSetSchema = buildSchema(preparedStatement.getMetaData());
+
+      listener.onNext(new Result(
+              Any.pack(ActionGetPreparedStatementResult.newBuilder()
+                      .setDatasetSchema(ByteString.copyFrom(pojoResultSetSchema.toByteArray()))
+                      .setParameterSchema(ByteString.copyFrom(pojoParameterMetaDataSchema.toByteArray()))
+                      .setPreparedStatementHandle(handle.toProtocol())
+                      .build())
+                      .toByteArray()));
+
+    } catch (ExecutionException | SQLException e) {
+      listener.onError(e);
+    } finally {
+      listener.onCompleted();
+    }
+  }
+
+  @Override
+  public FlightInfo getFlightInfoPreparedStatement(CommandPreparedStatementQuery command, FlightDescriptor descriptor,
+          CallContext context) {
+    try {
+      final ResultSet resultSet = commandExecutePreparedStatementLoadingCache.get(command);
+      final Schema schema = buildSchema(resultSet.getMetaData());
+
+      final List<FlightEndpoint> endpoints = ImmutableList
+              .of(new FlightEndpoint(new Ticket(Any.pack(command).toByteArray()), location));
+
+      return new FlightInfo(schema, descriptor, endpoints, -1, -1);
+    } catch (ExecutionException | SQLException e) {
+      logger.error("There was a problem executing the prepared statement", e);
+      throw new FlightRuntimeException(new CallStatus(FlightStatusCode.INTERNAL, e, e.getMessage(), null));
+    }
+  }
+
+  private Schema buildSchema(String catalog, String schema, String table) throws SQLException {
+    final List<Field> fields = new ArrayList<>();
+
+    try (final Connection connection = dataSource.getConnection();
+         final ResultSet columns = connection.getMetaData().getColumns(
+                 catalog,
+                 schema,
+                 table,
+                 null);) {
+
+      while (columns.next()) {
+        final String columnName = columns.getString("COLUMN_NAME");
+        final int jdbcDataType = columns.getInt("DATA_TYPE");
+        final String jdbcDataTypeName = columns.getString("TYPE_NAME");
+        final String jdbcIsNullable = columns.getString("IS_NULLABLE");
+        final boolean arrowIsNullable = jdbcIsNullable.equals("YES");
+
+        final int precision = columns.getInt("DECIMAL_DIGITS");
+        final int scale = columns.getInt("COLUMN_SIZE");
+        final ArrowType arrowType = FlightSQLUtils.getArrowTypeFromJDBCType(jdbcDataType, precision, scale);
+
+        final FieldType fieldType = new FieldType(arrowIsNullable, arrowType, /*dictionary=*/null);
+        fields.add(new Field(columnName, fieldType, null));
+      }
+    }
+
+    return new Schema(fields);
+  }
+
+  @Override
+  public void getStreamPreparedStatement(CommandPreparedStatementQuery command, CallContext context, Ticket ticket,
+          ServerStreamListener listener) {
+    try {
+      final ResultSet resultSet = commandExecutePreparedStatementLoadingCache.get(command);
+      final ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+      final Schema schema = buildSchema(resultSetMetaData);
+      final DictionaryProvider dictionaryProvider = new DictionaryProvider.MapDictionaryProvider();
+
+      try (final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+           final VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+
+        listener.start(root, dictionaryProvider);
+        final int columnCount = resultSetMetaData.getColumnCount();
+
+        while (resultSet.next()) {
+          final int rowCounter = readBatch(resultSet, resultSetMetaData, root, columnCount);
+
+          for (int resultSetColumnCounter = 1; resultSetColumnCounter <= columnCount; resultSetColumnCounter++) {
+            final String columnName = resultSetMetaData.getColumnName(resultSetColumnCounter);
+            root.getVector(columnName).setValueCount(rowCounter);
+          }
+
+          root.setRowCount(rowCounter);
+          listener.putNext();
+        }
+      }
+    } catch (ExecutionException | SQLException e) {
+      listener.error(e);
+    } finally {
+      listener.completed();
+      commandExecutePreparedStatementLoadingCache.invalidate(command);
+    }
+  }
+
+  private int readBatch(ResultSet resultSet, ResultSetMetaData resultSetMetaData, VectorSchemaRoot root,
+          int columnCount) throws SQLException {
+    int rowCounter = 0;
+    do {
+      for (int resultSetColumnCounter = 1; resultSetColumnCounter <= columnCount; resultSetColumnCounter++) {
+        final String columnName = resultSetMetaData.getColumnName(resultSetColumnCounter);
+
+        final FieldVector fieldVector = root.getVector(columnName);
+
+        if (fieldVector instanceof VarCharVector) {
+          final String value = resultSet.getString(resultSetColumnCounter);
+          if (resultSet.wasNull()) {
+            // TODO handle null
+          } else {
+            ((VarCharVector) fieldVector).setSafe(rowCounter, value.getBytes(), 0, value.length());
+          }
+        } else if (fieldVector instanceof IntVector) {
+          final int value = resultSet.getInt(resultSetColumnCounter);
+
+          if (resultSet.wasNull()) {
+            // TODO handle null
+          } else {
+            ((IntVector) fieldVector).setSafe(rowCounter, value);
+          }
+        } else {
+          throw new UnsupportedOperationException();
+        }
+      }
+      rowCounter++;
+    }
+    while (rowCounter < BATCH_ROW_SIZE && resultSet.next());
+
+    return rowCounter;
+  }
+
+
+  @Override
+  public void closePreparedStatement(FlightSQL.ActionClosePreparedStatementRequest request, CallContext context,
+          StreamListener<Result> listener) {
+    try {
+      preparedStatementLoadingCache.invalidate(
+              PreparedStatementCacheKey.fromProtocol(request.getPreparedStatementHandleBytes()));
+    } catch (InvalidProtocolBufferException e) {
+      listener.onError(e);
+    } finally {
+      listener.onCompleted();
+    }
+  }
+
+  private Schema buildSchema(ResultSetMetaData resultSetMetaData) throws SQLException {
+    Preconditions.checkNotNull(resultSetMetaData, "ResultSetMetaData object can't be null");
+    final List<Field> resultSetFields = new ArrayList<>();
+
+    for (int resultSetCounter = 1; resultSetCounter <= resultSetMetaData.getColumnCount(); resultSetCounter++) {
+      final String name = resultSetMetaData.getColumnName(resultSetCounter);
+
+      final int jdbcDataType = resultSetMetaData.getColumnType(resultSetCounter);
+
+      final int jdbcIsNullable = resultSetMetaData.isNullable(resultSetCounter);
+      final boolean arrowIsNullable = jdbcIsNullable == ResultSetMetaData.columnNullable;
+
+      final int precision = resultSetMetaData.getPrecision(resultSetCounter);
+      final int scale = resultSetMetaData.getScale(resultSetCounter);
+
+      final ArrowType arrowType = getArrowTypeFromJDBCType(jdbcDataType, precision, scale);
+
+      final FieldType fieldType = new FieldType(arrowIsNullable, arrowType, /*dictionary=*/null);
+      resultSetFields.add(new Field(name, fieldType, null));
+    }
+    final Schema pojoResultSetSchema = new Schema(resultSetFields);
+    return pojoResultSetSchema;
+  }
+
+  private Schema buildSchema(ParameterMetaData parameterMetaData) throws SQLException {
+    Preconditions.checkNotNull(parameterMetaData, "ParameterMetaData object can't be null");
+    final List<Field> parameterFields = new ArrayList<>();
+
+    for (int parameterCounter = 1; parameterCounter <= parameterMetaData.getParameterCount(); parameterCounter++) {
+      final int jdbcDataType = parameterMetaData.getParameterType(parameterCounter);
+
+      final int jdbcIsNullable = parameterMetaData.isNullable(parameterCounter);
+      final boolean arrowIsNullable = jdbcIsNullable == ParameterMetaData.parameterNullable;
+
+      final int precision = parameterMetaData.getPrecision(parameterCounter);
+      final int scale = parameterMetaData.getScale(parameterCounter);
+
+      final ArrowType arrowType = getArrowTypeFromJDBCType(jdbcDataType, precision, scale);
+
+      final FieldType fieldType = new FieldType(arrowIsNullable, arrowType, /*dictionary=*/null);
+      parameterFields.add(new Field(null, fieldType, null));
+    }
+    final Schema pojoParameterMetaDataSchema = new Schema(parameterFields);
+    return pojoParameterMetaDataSchema;
+  }
+
+  @Override
+  public void close() throws Exception {
+    try {
+      commandExecutePreparedStatementLoadingCache.cleanUp();
+    } catch (Throwable e) {
+      // Swallow
+    }
+
+    try {
+      preparedStatementLoadingCache.cleanUp();
+    } catch (Throwable e) {
+      // Swallow
+    }
+
+    AutoCloseables.close(dataSource);
+  }
+
+  private static class CommandExecutePreparedStatementRemovalListener
+          implements RemovalListener<CommandPreparedStatementQuery, ResultSet> {
+    @Override
+    public void onRemoval(RemovalNotification<CommandPreparedStatementQuery, ResultSet> notification) {
+      try {
+        AutoCloseables.close(notification.getValue());
+      } catch (Throwable e) {
+        // Swallow
+      }
+    }
+  }
+
+  private static class CommandExecutePreparedStatementCacheLoader
+          extends CacheLoader<CommandPreparedStatementQuery, ResultSet> {
+
+    private final LoadingCache<PreparedStatementCacheKey, PreparedStatementContext> preparedStatementLoadingCache;
+
+    private CommandExecutePreparedStatementCacheLoader(LoadingCache<PreparedStatementCacheKey,
+            PreparedStatementContext> preparedStatementLoadingCache) {
+      this.preparedStatementLoadingCache = preparedStatementLoadingCache;
+    }
+
+    @Override
+    public ResultSet load(CommandPreparedStatementQuery commandExecutePreparedStatement)
+            throws SQLException, InvalidProtocolBufferException, ExecutionException {
+      final PreparedStatementCacheKey preparedStatementCacheKey =
+              PreparedStatementCacheKey.fromProtocol(commandExecutePreparedStatement.getPreparedStatementHandle());
+      final PreparedStatementContext preparedStatementContext = preparedStatementLoadingCache
+              .get(preparedStatementCacheKey);
+      return preparedStatementContext.getPreparedStatement().executeQuery();
+    }
+  }
+
+
+  private static class PreparedStatementRemovalListener implements RemovalListener<PreparedStatementCacheKey,
+          PreparedStatementContext> {
+    @Override
+    public void onRemoval(RemovalNotification<PreparedStatementCacheKey, PreparedStatementContext> notification) {
+      try {
+        AutoCloseables.close(notification.getValue());
+      } catch (Throwable e) {
+        // swallow
+      }
+    }
+  }
+
+  private static class PreparedStatementCacheLoader extends CacheLoader<PreparedStatementCacheKey,
+          PreparedStatementContext> {
+
+    // Owned by parent class.
+    private final PoolingDataSource<PoolableConnection> dataSource;
+
+    private PreparedStatementCacheLoader(PoolingDataSource<PoolableConnection> dataSource) {
+      this.dataSource = dataSource;
+    }
+
+    @Override
+    public PreparedStatementContext load(PreparedStatementCacheKey key) throws SQLException {
+
+      // Ownership of the connection will be passed to the context.
+      final Connection connection = dataSource.getConnection();
+      try {
+        final PreparedStatement preparedStatement = connection.prepareStatement(key.getSql());
+        return new PreparedStatementContext(connection, preparedStatement);
+      } catch (SQLException e) {
+        connection.close();
+        throw e;
+      }
+    }
+  }
+
+  private static void removeDerbyDatabaseIfExists() {
+    final Path path = Paths.get("target" + File.separator + "derbyDB");
+
+    try (final Stream<Path> walk = Files.walk(path)) {
+      walk.sorted(Comparator.reverseOrder())
+              .map(Path::toFile)
+              .forEach(File::delete);
+    } catch (NoSuchFileException e) {
+      // Ignore as there was no data directory to clean up.
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to remove derby data directory.", e);
+    }
+  }
+
+  private static void populateDerbyDatabase() {
+    try (final Connection conn = DriverManager.getConnection("jdbc:derby:target/derbyDB;create=true")) {
+      conn.createStatement().execute("CREATE TABLE intTable (keyName varchar(100), value int)");
+      conn.createStatement().execute("INSERT INTO intTable (keyName, value) VALUES ('one', 1)");
+      conn.createStatement().execute("INSERT INTO intTable (keyName, value) VALUES ('zero', 0)");
+      conn.createStatement().execute("INSERT INTO intTable (keyName, value) VALUES ('negative one', -1)");
+    } catch (SQLException e) {
+      throw new RuntimeException("Failed to create derby database.", e);
+    }
+  }
+
+
+  @Override
+  public void listFlights(CallContext context, Criteria criteria, StreamListener<FlightInfo> listener) {
+    // TODO - build example implementation
+    throw Status.UNIMPLEMENTED.asRuntimeException();
+  }
+
+  @Override
+  public FlightInfo getFlightInfoStatement(CommandStatementQuery command, FlightDescriptor descriptor,
+          CallContext context) {
+    // TODO - build example implementation
+    throw Status.UNIMPLEMENTED.asRuntimeException();
+  }
+
+  @Override
+  public SchemaResult getSchema(CallContext context, FlightDescriptor descriptor) {
+    // TODO - build example implementation
+    throw Status.UNIMPLEMENTED.asRuntimeException();
+  }
+
+  @Override
+  public void doExchange(CallContext context, FlightStream reader, ServerStreamListener writer) {
+    // TODO - build example implementation
+    throw Status.UNIMPLEMENTED.asRuntimeException();
+  }
+
+  @Override
+  public void getSqlCapabilities(CallContext context, StreamListener<Result> listener) {
+    // TODO - build example implementation
+    throw Status.UNIMPLEMENTED.asRuntimeException();
+  }
+
+  @Override
+  public void getCatalogs(FlightSQL.ActionGetCatalogsRequest request, CallContext context,
+          StreamListener<Result> listener) {
+    // TODO - build example implementation
+    throw Status.UNIMPLEMENTED.asRuntimeException();
+  }
+
+  @Override
+  public void getSchemas(FlightSQL.ActionGetSchemasRequest request, CallContext context,
+          StreamListener<Result> listener) {
+    // TODO - build example implementation
+    throw Status.UNIMPLEMENTED.asRuntimeException();
+  }
+
+  @Override
+  public void getTableTypes(CallContext context, StreamListener<Result> listener) {
+    // TODO - build example implementation
+    throw Status.UNIMPLEMENTED.asRuntimeException();
+  }
+
+  @Override
+  public SchemaResult getSchemaStatement(CommandStatementQuery command, FlightDescriptor descriptor,
+          CallContext context) {
+    // TODO - build example implementation
+    throw Status.UNIMPLEMENTED.asRuntimeException();
+  }
+
+  @Override
+  public Runnable acceptPutStatement(CommandStatementUpdate command,
+          CallContext context, FlightStream flightStream, StreamListener<PutResult> ackStream) {
+    // TODO - build example implementation
+    throw Status.UNIMPLEMENTED.asRuntimeException();
+  }
+
+  @Override
+  public Runnable acceptPutPreparedStatementUpdate(CommandPreparedStatementUpdate command, CallContext context,
+          FlightStream flightStream, StreamListener<PutResult> ackStream) {
+    // TODO - build example implementation
+    throw Status.UNIMPLEMENTED.asRuntimeException();
+  }
+
+  @Override
+  public Runnable acceptPutPreparedStatementQuery(CommandPreparedStatementQuery command, CallContext context,
+          FlightStream flightStream, StreamListener<PutResult> ackStream) {
+    // TODO - build example implementation
+    throw Status.UNIMPLEMENTED.asRuntimeException();
+  }
+
+  @Override
+  public void getStreamStatement(CommandStatementQuery command, CallContext context, Ticket ticket,
+          ServerStreamListener listener) {
+    throw Status.UNIMPLEMENTED.asRuntimeException();
+  }
+
+}

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/FlightSQLExample.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/FlightSQLExample.java
@@ -188,7 +188,7 @@ public class FlightSQLExample extends FlightSQLProducer implements AutoCloseable
 
     if (includeSchema) {
       final Schema pojoSchema = buildSchema(catalog, schema, table);
-      builder.setSchemaMetadata(ByteString.copyFrom(pojoSchema.toByteArray()));
+      builder.setArrowMetadata(ByteString.copyFrom(pojoSchema.toByteArray()));
     }
 
     return new Result(Any.pack(builder.build()).toByteArray());

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/FlightSQLExample.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/FlightSQLExample.java
@@ -539,7 +539,7 @@ public class FlightSQLExample extends FlightSQLProducer implements AutoCloseable
   }
 
   @Override
-  public void getSqlCapabilities(CallContext context, StreamListener<Result> listener) {
+  public void getSqlInfo(CallContext context, StreamListener<Result> listener) {
     // TODO - build example implementation
     throw Status.UNIMPLEMENTED.asRuntimeException();
   }

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/PreparedStatementCacheKey.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/PreparedStatementCacheKey.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight.sql;
+
+import java.util.Objects;
+
+import org.apache.arrow.flight.sql.impl.FlightSQLExample.PreparedStatementHandle;
+import org.apache.arrow.util.Preconditions;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+class PreparedStatementCacheKey {
+
+  private final String uuid;
+  private final String sql;
+
+  PreparedStatementCacheKey(final String uuid, final String sql) {
+    this.uuid = uuid;
+    this.sql = sql;
+  }
+
+  String getUuid() {
+    return uuid;
+  }
+
+  String getSql() {
+    return sql;
+  }
+
+  ByteString toProtocol() {
+    return Any.pack(org.apache.arrow.flight.sql.impl.FlightSQLExample.PreparedStatementHandle
+            .newBuilder()
+            .setSql(getSql())
+            .setUuid(getUuid())
+            .build())
+            .toByteString();
+  }
+
+  static PreparedStatementCacheKey fromProtocol(ByteString byteString) throws InvalidProtocolBufferException {
+    final Any parsed = Any.parseFrom(byteString);
+    Preconditions.checkArgument(parsed.is(PreparedStatementHandle.class));
+
+    final PreparedStatementHandle preparedStatementHandle = parsed.unpack(PreparedStatementHandle.class);
+    return new PreparedStatementCacheKey(preparedStatementHandle.getUuid(), preparedStatementHandle.getSql());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PreparedStatementCacheKey)) {
+      return false;
+    }
+
+    PreparedStatementCacheKey that = (PreparedStatementCacheKey) o;
+
+    return Objects.equals(uuid, that.uuid) &&
+            Objects.equals(sql, that.sql);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(uuid, sql);
+  }
+}

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/PreparedStatementContext.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/PreparedStatementContext.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight.sql;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.Objects;
+
+import org.apache.arrow.util.AutoCloseables;
+
+class PreparedStatementContext implements AutoCloseable {
+
+  private final Connection connection;
+  private final PreparedStatement preparedStatement;
+
+  PreparedStatementContext(Connection connection, PreparedStatement preparedStatement) {
+    this.preparedStatement = preparedStatement;
+    this.connection = connection;
+  }
+
+  PreparedStatement getPreparedStatement() {
+    return preparedStatement;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof PreparedStatementContext)) {
+      return false;
+    }
+
+    PreparedStatementContext that = (PreparedStatementContext) o;
+
+    return Objects.equals(connection, that.connection) &&
+            Objects.equals(preparedStatement, that.preparedStatement);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(connection, preparedStatement);
+  }
+
+  @Override
+  public void close() throws Exception {
+    AutoCloseables.close(preparedStatement, connection);
+  }
+}

--- a/java/flight/flight-sql/src/test/protobuf/flightSQLExample.proto
+++ b/java/flight/flight-sql/src/test/protobuf/flightSQLExample.proto
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+option java_package = "org.apache.arrow.flight.sql.impl";
+
+message PreparedStatementHandle {
+  string uuid = 1;
+  string sql = 2;
+}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -673,6 +673,7 @@
     <module>plasma</module>
     <module>flight/flight-core</module>
     <module>flight/flight-grpc</module>
+    <module>flight/flight-sql</module>
     <module>performance</module>
     <module>algorithm</module>
     <module>adapter/avro</module>


### PR DESCRIPTION
Add extensions in the Apache Arrow project’s Arrow Flight modules
to provide a standard way for clients and servers to communicate
with SQL-like semantics.

Do not pull to master. A message to the mailing list will accompany this
and another proposal in the coming days for discussion.